### PR TITLE
Fix binder support by adding torchvision, torchtest, and opencv to environment.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Mini Course in Deep Learning with PyTorch for AIMS
-[![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/Atcold/PyTorch-Deep-Learning-Minicourse/master)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/Atcold/pytorch-Deep-Learning-Minicourse/master)
 
 The African Masters of Machine Intelligence (AMMI) is Africa's flagship program in machine intelligence led by The African Institute for Mathematical Sciences (AIMS).
 These lessons, developed during the course of several years while I've been teaching at Purdue and NYU, are here proposed for the AMMI (AIMS).

--- a/apt.txt
+++ b/apt.txt
@@ -1,0 +1,1 @@
+libgl1-mesa-glx

--- a/environment.yml
+++ b/environment.yml
@@ -4,6 +4,11 @@ channels:
   - pytorch
 dependencies:
   - python=3.6
+  - pip
   - pytorch=0.4.1
+  - torchvision
+  - opencv
   - matplotlib
   - jupyter
+  - pip:
+    - torchtext


### PR DESCRIPTION
Hi @Atcold. I was recently recommending your minicourse but I saw that as the result of recent course development the Binder for it is broken. Specifically, `torchvision` and `torchtext` are now used and are not part of the current `environment.yml`. In addition, in Notebook 10 `opencv` is used. In the notebook you install it in the environment using Jupyter shell magics, but this can't be done in Binder as the user doesn't have access to `conda` once they are in the built image. To fix this `opencv` is added to `environment.yml` and an `apt.txt` file is added which contains `libgl1-mesa-glx` for [Binder to install with apt-get](https://mybinder.readthedocs.io/en/latest/config_files.html#apt-txt-install-packages-with-apt-get) to provide some of the OS libraries that `opencv` needs.

Please let me know your thoughts on all of this and if you would like any of these changes (or none of them). If you want to try out the new environment in Binder you can try the image built from my fork: [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/matthewfeickert/PyTorch-Deep-Learning-Minicourse/fix/fix-Binder-support)