### PR TITLE
changed W to W transpose

### DIFF
--- a/02-space_stretching.ipynb
+++ b/02-space_stretching.ipynb
@@ -89,7 +89,7 @@
     "    # create a random matrix\n",
     "    W = torch.randn(2, 2).to(device)\n",
     "    # transform points\n",
-    "    Y = X @ W\n",
+    "    Y = X @ torch.t(W)\n",
     "    # compute singular values\n",
     "    U, S, V = torch.svd(W)\n",
     "    # plot transformed points\n",
@@ -279,7 +279,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "version": "3.7.2"
   }
  },
  "nbformat": 4,

--- a/02-space_stretching.ipynb
+++ b/02-space_stretching.ipynb
@@ -89,7 +89,7 @@
     "    # create a random matrix\n",
     "    W = torch.randn(2, 2).to(device)\n",
     "    # transform points\n",
-    "    Y = X @ torch.t(W)\n",
+    "    Y = X @ W.t()\n",
     "    # compute singular values\n",
     "    U, S, V = torch.svd(W)\n",
     "    # plot transformed points\n",
@@ -187,9 +187,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "source": [
     "# Visualize Functions Represented by Random Neural Networks"
    ]


### PR DESCRIPTION
For linear transformation, we should actually do 
`Y = X* W^T` rather than `Y = X*W` considering we want to perform linear transformation `W`.

If we want to perform linear transformation `W^T`, then we will need to change `svd(W)` to `svd(W^T)`.