### PR TITLE
Fixed test loss calculation bug

### DIFF
--- a/14-truck_backer-upper.ipynb
+++ b/14-truck_backer-upper.ipynb
@@ -383,8 +383,8 @@
     "        next_state = test_outputs[idx]\n",
     "        total_loss += criterion(next_state_prediction, next_state).item()\n",
     "\n",
-    "    \n",
-    "print(f'Test loss: {loss.item():.10f}')"
+    "ave_test_loss = total_loss/test_size\n",
+    "print(f'Test loss: {ave_test_loss:.10f}')"
    ]
   },
   {
@@ -416,7 +416,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "version": "3.7.2"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Hi! I have modified the test loss calculation in 14-truck_backer-upper to correctly compute the test loss, and here is a pull request! Thank you! 