### PR TITLE
Updates to current packages

### DIFF
--- a/01-tensor_tutorial.ipynb
+++ b/01-tensor_tutorial.ipynb
@@ -910,9 +910,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:aims-ml] *",
+   "display_name": "Python [conda env:dl-minicourse] *",
    "language": "python",
-   "name": "conda-env-aims-ml-py"
+   "name": "conda-env-dl-minicourse-py"
   },
   "language_info": {
    "codemirror_mode": {

--- a/01-tensor_tutorial.ipynb
+++ b/01-tensor_tutorial.ipynb
@@ -910,9 +910,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python [conda env:aims-ml] *",
    "language": "python",
-   "name": "python3"
+   "name": "conda-env-aims-ml-py"
   },
   "language_info": {
    "codemirror_mode": {
@@ -924,9 +924,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }

--- a/02-space_stretching.ipynb
+++ b/02-space_stretching.ipynb
@@ -35,9 +35,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# generate some points in 2-D space\n",
@@ -77,9 +75,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "show_scatterplot(X, colors, title='X')\n",
@@ -111,9 +107,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "model = nn.Sequential(\n",
@@ -162,9 +156,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "show_scatterplot(X, colors, title='X')\n",
@@ -195,9 +187,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "show_scatterplot(X, colors, title='x')\n",
@@ -223,9 +213,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# deeper network with random weights\n",
@@ -263,9 +251,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python [conda env:aims-ml] *",
    "language": "python",
-   "name": "python3"
+   "name": "conda-env-aims-ml-py"
   },
   "language_info": {
    "codemirror_mode": {
@@ -277,9 +265,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.2"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/02-space_stretching.ipynb
+++ b/02-space_stretching.ipynb
@@ -251,9 +251,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:aims-ml] *",
+   "display_name": "Python [conda env:dl-minicourse] *",
    "language": "python",
-   "name": "conda-env-aims-ml-py"
+   "name": "conda-env-dl-minicourse-py"
   },
   "language_info": {
    "codemirror_mode": {

--- a/03-autograd_tutorial.ipynb
+++ b/03-autograd_tutorial.ipynb
@@ -306,9 +306,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:aims-ml] *",
+   "display_name": "Python [conda env:dl-minicourse] *",
    "language": "python",
-   "name": "conda-env-aims-ml-py"
+   "name": "conda-env-dl-minicourse-py"
   },
   "language_info": {
    "codemirror_mode": {

--- a/03-autograd_tutorial.ipynb
+++ b/03-autograd_tutorial.ipynb
@@ -306,9 +306,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python [conda env:aims-ml] *",
    "language": "python",
-   "name": "python3"
+   "name": "conda-env-aims-ml-py"
   },
   "language_info": {
    "codemirror_mode": {
@@ -320,9 +320,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/03-autograd_tutorial.ipynb
+++ b/03-autograd_tutorial.ipynb
@@ -287,8 +287,10 @@
     "    x = torch.arange(1., n + 1)\n",
     "    w = torch.ones(n, requires_grad=True)\n",
     "    z = w @ x\n",
-    "    z.backward()\n",
-    "    print(x.grad, w.grad, sep='\\n')"
+    "    try:\n",
+    "        z.backward()\n",
+    "    except RuntimeError as e:\n",
+    "        print(e)"
    ]
   },
   {

--- a/03-autograd_tutorial.ipynb
+++ b/03-autograd_tutorial.ipynb
@@ -282,13 +282,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Regardless of what you do in this loop, all torch tensors will not have gradient accumulation\n",
+    "# Regardless of what you do in this context, all torch tensors will not have gradient accumulation\n",
     "with torch.no_grad():\n",
-    "    x = torch.arange(1., n + 1)\n",
+    "    x = torch.arange(1., n + 1, requires_grad=True)\n",
     "    w = torch.ones(n, requires_grad=True)\n",
     "    z = w @ x\n",
+    "\n",
     "    try:\n",
-    "        z.backward()\n",
+    "        z.backward()  # PyTorch 1.x will throw an error here, since z has no grad accum.\n",
+    "        print(x.grad, w.grad, sep='\\n')\n",
     "    except RuntimeError as e:\n",
     "        print(e)"
    ]

--- a/03-autograd_tutorial.ipynb
+++ b/03-autograd_tutorial.ipynb
@@ -282,16 +282,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "x = torch.arange(1., n + 1)\n",
+    "w = torch.ones(n, requires_grad=True)\n",
+    "\n",
     "# Regardless of what you do in this context, all torch tensors will not have gradient accumulation\n",
     "with torch.no_grad():\n",
-    "    x = torch.arange(1., n + 1)\n",
-    "    w = torch.ones(n, requires_grad=True)\n",
     "    z = w @ x\n",
     "\n",
-    "    try:\n",
-    "        z.backward()  # PyTorch will throw an error here, since z has no grad accum.\n",
-    "    except RuntimeError as e:\n",
-    "        print(e)"
+    "try:\n",
+    "    z.backward()  # PyTorch will throw an error here, since z has no grad accum.\n",
+    "except RuntimeError as e:\n",
+    "    print(e)"
    ]
   },
   {

--- a/03-autograd_tutorial.ipynb
+++ b/03-autograd_tutorial.ipynb
@@ -284,13 +284,12 @@
    "source": [
     "# Regardless of what you do in this context, all torch tensors will not have gradient accumulation\n",
     "with torch.no_grad():\n",
-    "    x = torch.arange(1., n + 1, requires_grad=True)\n",
+    "    x = torch.arange(1., n + 1)\n",
     "    w = torch.ones(n, requires_grad=True)\n",
     "    z = w @ x\n",
     "\n",
     "    try:\n",
-    "        z.backward()  # PyTorch 1.x will throw an error here, since z has no grad accum.\n",
-    "        print(x.grad, w.grad, sep='\\n')\n",
+    "        z.backward()  # PyTorch will throw an error here, since z has no grad accum.\n",
     "    except RuntimeError as e:\n",
     "        print(e)"
    ]

--- a/04-spiral_classification.ipynb
+++ b/04-spiral_classification.ipynb
@@ -272,9 +272,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:aims-ml] *",
+   "display_name": "Python [conda env:dl-minicourse] *",
    "language": "python",
-   "name": "conda-env-aims-ml-py"
+   "name": "conda-env-dl-minicourse-py"
   },
   "language_info": {
    "codemirror_mode": {

--- a/04-spiral_classification.ipynb
+++ b/04-spiral_classification.ipynb
@@ -272,9 +272,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python [conda env:aims-ml] *",
    "language": "python",
-   "name": "python3"
+   "name": "conda-env-aims-ml-py"
   },
   "language_info": {
    "codemirror_mode": {
@@ -286,9 +286,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/05-regression.ipynb
+++ b/05-regression.ipynb
@@ -340,9 +340,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python [conda env:aims-ml] *",
    "language": "python",
-   "name": "python3"
+   "name": "conda-env-aims-ml-py"
   },
   "language_info": {
    "codemirror_mode": {
@@ -354,9 +354,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/05-regression.ipynb
+++ b/05-regression.ipynb
@@ -340,9 +340,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:aims-ml] *",
+   "display_name": "Python [conda env:dl-minicourse] *",
    "language": "python",
-   "name": "conda-env-aims-ml-py"
+   "name": "conda-env-dl-minicourse-py"
   },
   "language_info": {
    "codemirror_mode": {

--- a/06-convnet.ipynb
+++ b/06-convnet.ipynb
@@ -436,9 +436,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:aims-ml] *",
+   "display_name": "Python [conda env:dl-minicourse] *",
    "language": "python",
-   "name": "conda-env-aims-ml-py"
+   "name": "conda-env-dl-minicourse-py"
   },
   "language_info": {
    "codemirror_mode": {

--- a/06-convnet.ipynb
+++ b/06-convnet.ipynb
@@ -89,9 +89,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "input_size  = 28*28   # images are 28x28 pixels\n",
@@ -311,9 +309,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "perm = torch.randperm(784)\n",
@@ -440,9 +436,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python [conda env:aims-ml] *",
    "language": "python",
-   "name": "python3"
+   "name": "conda-env-aims-ml-py"
   },
   "language_info": {
    "codemirror_mode": {
@@ -454,9 +450,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/07-listening_to_kernels.ipynb
+++ b/07-listening_to_kernels.ipynb
@@ -91,9 +91,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Visualise x(t)\n",
@@ -317,9 +315,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python [conda env:aims-ml] *",
    "language": "python",
-   "name": "python3"
+   "name": "conda-env-aims-ml-py"
   },
   "language_info": {
    "codemirror_mode": {
@@ -331,9 +329,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/07-listening_to_kernels.ipynb
+++ b/07-listening_to_kernels.ipynb
@@ -19,17 +19,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Let's install a library for reading audio...\n",
-    "! pip install librosa"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "#... and inport it\n",
+    "# Let's use a library we've included for reading audio:\n",
     "import librosa"
    ]
   },
@@ -230,7 +220,7 @@
    "source": [
     "# Let's compute the STFT of the reconstruction\n",
     "XX = librosa.stft(xx)\n",
-    "XX_dB = librosa.amplitude_to_db(XX)"
+    "XX_dB = librosa.amplitude_to_db(np.abs(XX))"
    ]
   },
   {

--- a/07-listening_to_kernels.ipynb
+++ b/07-listening_to_kernels.ipynb
@@ -315,9 +315,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:aims-ml] *",
+   "display_name": "Python [conda env:dl-minicourse] *",
    "language": "python",
-   "name": "conda-env-aims-ml-py"
+   "name": "conda-env-dl-minicourse-py"
   },
   "language_info": {
    "codemirror_mode": {

--- a/08-seq_classification.ipynb
+++ b/08-seq_classification.ipynb
@@ -556,9 +556,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:aims-ml] *",
+   "display_name": "Python [conda env:dl-minicourse] *",
    "language": "python",
-   "name": "conda-env-aims-ml-py"
+   "name": "conda-env-dl-minicourse-py"
   },
   "language_info": {
    "codemirror_mode": {

--- a/08-seq_classification.ipynb
+++ b/08-seq_classification.ipynb
@@ -556,9 +556,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python [conda env:aims-ml] *",
    "language": "python",
-   "name": "python3"
+   "name": "conda-env-aims-ml-py"
   },
   "language_info": {
    "codemirror_mode": {
@@ -570,9 +570,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/09-echo_data.ipynb
+++ b/09-echo_data.ipynb
@@ -2,9 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "source": [
     "# Signal echoing\n",
     "\n",
@@ -235,9 +233,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python [conda env:aims-ml] *",
    "language": "python",
-   "name": "python3"
+   "name": "conda-env-aims-ml-py"
   },
   "language_info": {
    "codemirror_mode": {
@@ -249,9 +247,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }

--- a/09-echo_data.ipynb
+++ b/09-echo_data.ipynb
@@ -233,9 +233,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:aims-ml] *",
+   "display_name": "Python [conda env:dl-minicourse] *",
    "language": "python",
-   "name": "conda-env-aims-ml-py"
+   "name": "conda-env-dl-minicourse-py"
   },
   "language_info": {
    "codemirror_mode": {

--- a/10-autoencoder.ipynb
+++ b/10-autoencoder.ipynb
@@ -145,9 +145,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Train standard or denoising autoencoder (AE)\n",
@@ -244,9 +242,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python [conda env:aims-ml] *",
    "language": "python",
-   "name": "python3"
+   "name": "conda-env-aims-ml-py"
   },
   "language_info": {
    "codemirror_mode": {
@@ -258,9 +256,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.1"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/10-autoencoder.ipynb
+++ b/10-autoencoder.ipynb
@@ -191,15 +191,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "! conda install -y --name codas-ml opencv"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "# Let's compare the autoencoder inpainting capabilities vs. OpenCV\n",
     "\n",
     "from cv2 import inpaint, INPAINT_NS, INPAINT_TELEA"

--- a/10-autoencoder.ipynb
+++ b/10-autoencoder.ipynb
@@ -242,9 +242,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:aims-ml] *",
+   "display_name": "Python [conda env:dl-minicourse] *",
    "language": "python",
-   "name": "conda-env-aims-ml-py"
+   "name": "conda-env-dl-minicourse-py"
   },
   "language_info": {
    "codemirror_mode": {

--- a/11-VAE.ipynb
+++ b/11-VAE.ipynb
@@ -159,9 +159,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Training and testing the VAE\n",
@@ -264,9 +262,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python [conda env:aims-ml] *",
    "language": "python",
-   "name": "python3"
+   "name": "conda-env-aims-ml-py"
   },
   "language_info": {
    "codemirror_mode": {
@@ -278,9 +276,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/11-VAE.ipynb
+++ b/11-VAE.ipynb
@@ -262,9 +262,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:aims-ml] *",
+   "display_name": "Python [conda env:dl-minicourse] *",
    "language": "python",
-   "name": "conda-env-aims-ml-py"
+   "name": "conda-env-dl-minicourse-py"
   },
   "language_info": {
    "codemirror_mode": {

--- a/12-regularization.ipynb
+++ b/12-regularization.ipynb
@@ -618,9 +618,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:aims-ml] *",
+   "display_name": "Python [conda env:dl-minicourse] *",
    "language": "python",
-   "name": "conda-env-aims-ml-py"
+   "name": "conda-env-dl-minicourse-py"
   },
   "language_info": {
    "codemirror_mode": {

--- a/12-regularization.ipynb
+++ b/12-regularization.ipynb
@@ -618,9 +618,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python [conda env:aims-ml] *",
    "language": "python",
-   "name": "python3"
+   "name": "conda-env-aims-ml-py"
   },
   "language_info": {
    "codemirror_mode": {
@@ -632,9 +632,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/13-bayesian_nn.ipynb
+++ b/13-bayesian_nn.ipynb
@@ -173,9 +173,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:aims-ml] *",
+   "display_name": "Python [conda env:dl-minicourse] *",
    "language": "python",
-   "name": "conda-env-aims-ml-py"
+   "name": "conda-env-dl-minicourse-py"
   },
   "language_info": {
    "codemirror_mode": {

--- a/13-bayesian_nn.ipynb
+++ b/13-bayesian_nn.ipynb
@@ -173,9 +173,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python [conda env:aims-ml] *",
    "language": "python",
-   "name": "python3"
+   "name": "conda-env-aims-ml-py"
   },
   "language_info": {
    "codemirror_mode": {
@@ -187,9 +187,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/14-truck_backer-upper.ipynb
+++ b/14-truck_backer-upper.ipynb
@@ -402,9 +402,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python [conda env:aims-ml] *",
    "language": "python",
-   "name": "python3"
+   "name": "conda-env-aims-ml-py"
   },
   "language_info": {
    "codemirror_mode": {
@@ -416,9 +416,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.2"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/14-truck_backer-upper.ipynb
+++ b/14-truck_backer-upper.ipynb
@@ -402,9 +402,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:aims-ml] *",
+   "display_name": "Python [conda env:dl-minicourse] *",
    "language": "python",
-   "name": "conda-env-aims-ml-py"
+   "name": "conda-env-dl-minicourse-py"
   },
   "language_info": {
    "codemirror_mode": {

--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ Please refer to this version release [here](https://github.com/Atcold/pytorch-De
 *Jupyter Notebooks* are used throughout these lectures for interactive data exploration and visualisation.
 
 We use dark styles for both *GitHub* and *Jupyter Notebook*.
-You should try to do the same, or they will look ugly.
-To see the content appropriately install the following:
+You should try to do the same, or they will look ugly. JupyterLab has a built-in selectable dark theme, so you only need to install something if you want to use the classic notebook interface.
+To see the content appropriately in the classic interface install the following:
 
  - [*Jupyter Notebook* dark theme](https://userstyles.org/styles/153443/jupyter-notebook-dark);
  - [*GitHub* dark theme](https://userstyles.org/styles/37035/github-dark) and comment out the `invert #fff to #181818` code block.
@@ -113,14 +113,7 @@ Change into the course folder, then type:
 ```bash
 #cd PyTorch-Deep-Learning-Minicourse
 conda env create -f environment.yml
-source activate aims-ml
-```
-
-## Enable anaconda kernel in Jupyter
-To make newly created miniconda environment visible in the Jupyter, install `ipykernel`:
-
-```bash
-python -m ipykernel install --user --name aims-ml --display-name "AIMS DL"
+source activate dl-minicourse
 ```
 
 ## Install Autocomplete by hinterland
@@ -130,11 +123,11 @@ pip install jupyter_contrib_nbextensions
 pip install jupyter_nbextensions_configurator
 jupyter contrib nbextension install --user
 
-cd /usr/local/miniconda3/envs/aims-ml/lib/python3.6/site-packages/jupyter_contrib_nbextensions/nbextensions
+cd /usr/local/miniconda3/envs/dl-minicourse/lib/python3.6/site-packages/jupyter_contrib_nbextensions/nbextensions
 jupyter nbextension install hinterland
 jupyter nbextension enable hinterland/hinterland
 ```
-## Start jupyter notebook
+## Start Jupyter notebook or JupyterLab
 If you are working in a JupyterLab container double click on "Files" tab in the upper right corner.
 Locate first notebook, double click to open.
 Do not attempt to start `jupyter` from the terminal window.
@@ -142,8 +135,15 @@ Do not attempt to start `jupyter` from the terminal window.
 If working on a laptop, start from terminal as usual:
 
 ```bash
+jupyter lab
+```
+
+Or, for the classic interface:
+
+```bash
 jupyter notebook
 ```
+
 
 ## More PyTorch Resources
 If you would like more PyTorch resources, head over to the global community-maintained repository of hundreds of reliable implementations and guides at the following repository created by Ritchie Ng: [The Incredible PyTorch](https://github.com/ritchieng/the-incredible-pytorch).

--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,4 @@
-name: aims-ml
+name: dl-minicourse
 channels:
   - conda-forge
   - pytorch

--- a/environment.yml
+++ b/environment.yml
@@ -3,13 +3,15 @@ channels:
   - conda-forge
   - pytorch
 dependencies:
-  - python=3.6
+  - python=3.7
   - pip
-  - pytorch=0.4.1
+  - pytorch=1.1
   - torchvision
   - opencv
   - matplotlib
-  - jupyter
+  - jupyterlab
+  - librosa
+  - nb_conda_kernels
   - pip:
     - torchtext
     - torchviz


### PR DESCRIPTION
This:

* Moves PyTorch from 0.4 to 1.1 (one tiny code change)
* Moves Python from 3.6 to 3.7 (no changes to code, just env)
* Moves 1-2 requirements out of notebooks and into environment (potential nasty scipy pip install from librosa avoided!)
* Uses conda kernels so the correct environment kernel is available (all notebooks rerun to pick up proper kernel)
* Adds JuptyerLab (not required, but nice) - the interactive backend in the final notebook is still best in the classic interface. Try out built-in dark mode!

All notebooks seem to run (except noted minor issue with JupyterLab)