### PR TITLE
mdbook themed website for class notes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ __pycache__
 *.pt
 *.png
 imdb
+
+.jekyll-cache
+_site

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "jekyllbook"]
+	path = jekyllbook
+	url = https://github.com/ebetica/jekyllbook

--- a/404.html
+++ b/404.html
@@ -1,0 +1,1 @@
+jekyllbook/404.html

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-# Mini Course in Deep Learning with PyTorch for AIMS
+---
+layout: default
+title: Mini Course in Deep Learning with PyTorch for AIMS
+---
+
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/Atcold/pytorch-Deep-Learning-Minicourse/master)
 
 The African Masters of Machine Intelligence (AMMI) is Africa's flagship program in machine intelligence led by The African Institute for Mathematical Sciences (AIMS).

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,33 @@
+permalink:           pretty
+
+# Setup
+title:               'PyTorch Deep Learning Minicourse'
+tagline:             'Gotta learn them all'
+url:                 https://ebetica.github.io/pytorch-Deep-Learning-Minicourse
+baseurl:             '/pytorch-Deep-Learning-Minicourse'
+
+# About/contact
+author:
+  name:              atcold
+  url:               https://twitter.com/atcold
+
+# Custom vars
+version:             dlsp20
+
+multilingual:        false
+src:                 "."
+default_theme:       "ayu"
+
+# For Maths
+markdown:            kramdown
+
+
+# Chapter Configuration (up to a 2 level nested list)
+
+chapters:
+  - path: chapters/01.md
+    sections:
+      - path: chapters/01-1.md
+      - path: chapters/01-2.md
+  - path: chapters/02.md
+

--- a/_layouts
+++ b/_layouts
@@ -1,0 +1,1 @@
+jekyllbook/_layouts

--- a/chapters/01-1.md
+++ b/chapters/01-1.md
@@ -1,0 +1,7 @@
+---
+layout: default
+title: Subtitle
+---
+
+Here's a subsection!
+

--- a/chapters/01-2.md
+++ b/chapters/01-2.md
@@ -1,0 +1,6 @@
+---
+layout: default
+title: Another subsection
+---
+
+Here's another subsection!

--- a/chapters/01.md
+++ b/chapters/01.md
@@ -1,0 +1,19 @@
+---
+layout: default
+title: Chapter 1
+---
+
+Here's chapter 1
+
+Here is some math: $$\mathcal{G} e^ix = \sin(x) + i \cos(x)$$
+
+Euler's identity $$e^{i\pi}+1=0$$ is a beautiful formula in $$\mathbb{2}$$.
+
+Here's a more complicated formula:
+
+$$
+\begin{aligned}
+a_{n+1} &= \frac{x_{n+1} + nc_n}{n+1} \\
+\iff a_{n+1} &= a_n + \frac{x_{n+1} - a_n}{n+1}
+\end{aligned}
+$$

--- a/chapters/02.md
+++ b/chapters/02.md
@@ -1,0 +1,6 @@
+---
+layout: default
+title: Chapter 2
+---
+
+Here's a chapter 2 :)

--- a/extra/plot_lib.py
+++ b/extra/plot_lib.py
@@ -1,1 +1,0 @@
-../plot_lib.py

--- a/index.md
+++ b/index.md
@@ -1,0 +1,1 @@
+README.md

--- a/static
+++ b/static
@@ -1,0 +1,1 @@
+jekyllbook/static


### PR DESCRIPTION
Hey - I eventually decided to just pull out the mdbook theme: I liked it a lot and it was nice to have it not be built. I have an example of the site in: https://ebetica.github.io/pytorch-Deep-Learning-Minicourse/chapters/01/

Check it out and let me know if you like it. The theme changing doesn't quite work (you have to refresh the page), but can fix it later. Katex works to write markdown, and you do not have to build the website. The sidebar structure is defined in _config.yml.

Developing locally is as simple as installing jekyll
```
gem install jekyll
```
and serving with
```
jekyll s --trace --baseurl ''
```