### PR TITLE
Update the link to PyTorch documentation

### DIFF
--- a/01-tensor_tutorial.ipynb
+++ b/01-tensor_tutorial.ipynb
@@ -903,7 +903,7 @@
     "There's definitely much more, but this was the basics about `Tensor`s fun.\n",
     "\n",
     "*Torch* full API should be read at least once.\n",
-    "Hence, go [here](http://pytorch.org/docs/0.3.0/torch.html).\n",
+    "Hence, go [here](https://pytorch.org/docs/stable/index.html).\n",
     "You'll find 100+ `Tensor` operations, including transposing, indexing, slicing, mathematical operations, linear algebra, random numbers, etc are described."
    ]
   }


### PR DESCRIPTION
Modified the link in the "tensor_tutorial" notebook to point to the latest (stable) version of PyTorch docs.