### PR TITLE
Updated environment.yml to fix (potential) versioning issue

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,10 +7,9 @@ dependencies:
   - pip
   - matplotlib
   - jupyterlab
-  - pytorch=1.4
-  - torchvision=0.5
+  - pytorch>=1.4
+  - torchvision>=0.5
   - torchtext
-  - pillow
   - opencv
   - librosa
   - nb_conda_kernels

--- a/environment.yml
+++ b/environment.yml
@@ -5,13 +5,14 @@ channels:
 dependencies:
   - python=3.7
   - pip
-  - pytorch=1.1
-  - torchvision
-  - opencv
   - matplotlib
   - jupyterlab
+  - pytorch=1.4
+  - torchvision=0.5
+  - torchtext
+  - pillow
+  - opencv
   - librosa
   - nb_conda_kernels
   - pip:
-    - torchtext
     - torchviz


### PR DESCRIPTION
This fixes the error produced by the CNN notebook when importing `torchvision`.

Apparently, `pillow` version 7.0 (latest) had some breaking changes, which were fixed in `torchvision` version 0.5 - more info here - https://github.com/pytorch/vision/pull/1501

The (probable) solution was to either downgrade `pillow` or update `torchvision` (and therefore `pytorch`).