### PR TITLE
[DLFL21] fix errors on running 15-transformers.ipynb

### DIFF
--- a/15-transformer.ipynb
+++ b/15-transformer.ipynb
@@ -749,7 +749,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 [conda env:pDL]",
    "language": "python",
    "name": "python3"
   },
@@ -763,7 +763,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.8.2"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
[DLFL21] 1. E.requires_grad=False need to be set before the operations; otheriwise, "runtimeerror: a view of a leaf variable that requires grad is being used in an in-place operation." will occur when initializing the model. 2. torchtext.legacy need to used when retrieving IMDB dataset in newest version of torch.