### PR TITLE
[DLSP25] Add Device Detection Section to PyTorch Tensor tutorial

### DIFF
--- a/01-tensor_tutorial.ipynb
+++ b/01-tensor_tutorial.ipynb
@@ -759,28 +759,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Check if a GPU is available\n",
-    "device = \"cuda\" if torch.cuda.is_available() else \"cpu\"\n",
-    "print(\"Device: \", device)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Checking for MPS\n",
-    "device = \"mps\" if torch.backends.mps.is_available() else \"cpu\"\n",
-    "print(\"Device: \", device)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "# Checking for available device (CPU, GPU, MPS)\n",
     "device = \"cuda\" if torch.cuda.is_available() else \"mps\" if torch.backends.mps.is_available() else \"cpu\"\n",
     "print(\"Device: \", device)"
@@ -1027,7 +1005,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.2"
+   "version": "3.13.5"
   }
  },
  "nbformat": 4,

--- a/01-tensor_tutorial.ipynb
+++ b/01-tensor_tutorial.ipynb
@@ -37,7 +37,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "torch.sq  # <Tab>"
+    "torch.sq  # <-- Press <Tab> to autocomplete"
    ]
   },
   {
@@ -744,6 +744,102 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Using the power of GPUs\n",
+    "\n",
+    "One of PyTorch’s greatest strengths is its ability to leverage GPUs for accelerated computations. However, **by default, PyTorch runs on the CPU**, so we need to explicitly move tensors to the GPU for optimal performance.\n",
+    "\n",
+    "> PyTorch supports CUDA for NVIDIA GPUs and MPS (Metal Performance Shaders) for Apple Silicon Macs, enabling much faster tensor operations compared to CPUs.\n",
+    "\n",
+    "**Important Note**: To perform operations between tensors, they must be on the same device (CPU, CUDA, or MPS). Mixing tensors from different devices will result in an error."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Check if a GPU is available\n",
+    "device = \"cuda\" if torch.cuda.is_available() else \"cpu\"\n",
+    "print(\"Device: \", device)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Checking for MPS\n",
+    "device = \"mps\" if torch.backends.mps.is_available() else \"cpu\"\n",
+    "print(\"Device: \", device)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Checking for available device (CPU, GPU, MPS)\n",
+    "device = \"cuda\" if torch.cuda.is_available() else \"mps\" if torch.backends.mps.is_available() else \"cpu\"\n",
+    "print(\"Device: \", device)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create a tensor on the CPU (default)\n",
+    "z = torch.ones(2, 3, 5)\n",
+    "\n",
+    "# Move tensor to the device\n",
+    "z.to(device)\n",
+    "print(f\"Tensor on {device}:\\n\", z)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Multiple GPUs?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Multiple GPUs? You can specify which one to use:\n",
+    "# e.g., move your tensor to GPU device 0 (first GPU in the system) if there is one\n",
+    "device = torch.device(\"cuda:0\" if torch.cuda.is_available() else \"cpu\")\n",
+    "z.to(device)\n",
+    "print(f\"Tensor on {device}:\\n\", z)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Not sure which of your GPUs is the first one for PyTorch?\n",
+    "gpus = []\n",
+    "\n",
+    "# List the available GPUs in order\n",
+    "if torch.cuda.is_available():\n",
+    "    gpus = [torch.cuda.get_device_name(i) for i in range(torch.cuda.device_count())]\n",
+    "\n",
+    "gpus"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Casting"
    ]
   },
@@ -856,6 +952,13 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -910,9 +1013,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:dl-minicourse] *",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "conda-env-dl-minicourse-py"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -924,7 +1027,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.13.2"
   }
  },
  "nbformat": 4,

--- a/01-tensor_tutorial.ipynb
+++ b/01-tensor_tutorial.ipynb
@@ -796,8 +796,8 @@
     "z = torch.ones(2, 3, 5)\n",
     "\n",
     "# Move tensor to the device\n",
-    "z.to(device)\n",
-    "print(f\"Tensor on {device}:\\n\", z)"
+    "z_1 = z.to(device) # Remember: when moving tensors to a device, you have to reassign them!\n",
+    "print(f\"Tensor on {device}:\\n\", z_1)"
    ]
   },
   {
@@ -816,8 +816,8 @@
     "# Multiple GPUs? You can specify which one to use:\n",
     "# e.g., move your tensor to GPU device 0 (first GPU in the system) if there is one\n",
     "device = torch.device(\"cuda:0\" if torch.cuda.is_available() else \"cpu\")\n",
-    "z.to(device)\n",
-    "print(f\"Tensor on {device}:\\n\", z)"
+    "z_2 = z.to(device)\n",
+    "print(f\"Tensor on {device}:\\n\", z_2)"
    ]
   },
   {


### PR DESCRIPTION
# Adding GPU Device Detection Section to Tutorial 🤖
> lom2017@nyu.edu

This update extends the **PyTorch tensor tutorial** by adding a subsection for device detection. Since PyTorch can leverage **CUDA** (for NVIDIA GPUs 🟢) and **MPS** (for Apple Silicon 🍎), this tutorial should (and now does) explicitly cover how to check for available devices and move tensors accordingly. 

## What's New?  

- Introduced a new section
- Explained how to check for available devices (`CUDA`, `MPS`, or `CPU`).  
    - Added a helper snippet to detect **all available devices** (`CUDA`, `MPS`, or fallback to `CPU`).  
- Provided code snippets to move tensors between devices.  


### Other small changes

Changed:
```python
torch.sq  # <Tab>
```
to 
```python
torch.sq  # <-- Press <Tab> to autocomplete
```
to better indicate that this is an autocomplete suggestion, as running it directly will cause an error.