### PR TITLE
Add search bar and print PDF buttons

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
-[submodule "jekyllbook"]
-	path = docs/jekyllbook
-	url = https://github.com/ebetica/jekyllbook
+[submodule "docs/jekyllbook"]
+    path = docs/jekyllbook
+    url = https://github.com/lbourdois/jekyllbook

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -40,6 +40,16 @@ exclude:
   - en/index.md
   - vendor
 
+# Print cover page configuration
+print_cover_title: "New York University Deep Learning Course"
+print_cover_subtitle: "2020 Edition"
+print_cover_tagline: "Course by Yann LeCun and Alfredo Canziani"
+
+print_cover_title_fr: "Cours d'apprentissage profond de la New York University"
+print_cover_subtitle_fr: "Edition 2020"
+print_cover_tagline_fr: "Le cours de Yann LE CUN et Alfredo CANZIANI"
+print_cover_translation_fr: "traduit en français par Loïck BOURDOIS"
+
 ################################### English ####################################
 prologues:
   - path: en/faq.md

--- a/docs/ar/print.md
+++ b/docs/ar/print.md
@@ -1,0 +1,7 @@
+---
+layout: default
+title: Print
+lang-ref: print
+permalink: /ar/print/
+print_page: true
+---

--- a/docs/ar/print.md
+++ b/docs/ar/print.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Print
+lang: ar
 lang-ref: print
 permalink: /ar/print/
 print_page: true

--- a/docs/bn/print.md
+++ b/docs/bn/print.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Print
+lang: bn
 lang-ref: print
 permalink: /bn/print/
 print_page: true

--- a/docs/bn/print.md
+++ b/docs/bn/print.md
@@ -1,0 +1,7 @@
+---
+layout: default
+title: Print
+lang-ref: print
+permalink: /bn/print/
+print_page: true
+---

--- a/docs/es/print.md
+++ b/docs/es/print.md
@@ -1,0 +1,7 @@
+---
+layout: default
+title: Print
+lang-ref: print
+permalink: /es/print/
+print_page: true
+---

--- a/docs/es/print.md
+++ b/docs/es/print.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Print
+lang: es
 lang-ref: print
 permalink: /es/print/
 print_page: true

--- a/docs/fa/print.md
+++ b/docs/fa/print.md
@@ -1,0 +1,7 @@
+---
+layout: default
+title: Print
+lang-ref: print
+permalink: /fa/print/
+print_page: true
+---

--- a/docs/fa/print.md
+++ b/docs/fa/print.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Print
+lang: fa
 lang-ref: print
 permalink: /fa/print/
 print_page: true

--- a/docs/fr/faq.md
+++ b/docs/fr/faq.md
@@ -35,7 +35,8 @@ Voici quelques réponses à des questions fréquemment posées :
 -	**Combien de temps consacrer à ce cours ?**  
 > Pour chaque semaine, il y a environ 2h30/3h de contenu vidéo. Avec le temps consacré à la prise de notes et celui pour jouer avec les *notebooks*, une estimation totale de 5h par semaine semble raisonnable. Pour la suite, cela dépend du niveau d'immersion que vous voulez atteindre dans un sujet donné (lire les articles donnés en référence, appliquer ce qui a été vu en classe à vos propres projets, etc.).
 -	**Où poser une question à l’issue du visionnage d’une vidéo ?**  
->	Vous pouvez la poser directement (en anglais) dans la section commentaires sous la vidéo YouTube en question, Alfredo se fera un plaisir d’y répondre. Si cette question porte sur un point précis de la vidéo, pensez à indiquer l’horodatage. Vous pouvez le faire également sur le [Discord](https://discord.gg/CthuqsX8Pb) de la classe dédié expressément aux étudiants. Il sert également à coordonner des groupes de visionnage, discuter des devoirs, suggérer des améliorations ou plus généralement pour tout sujet lié au cours.
+>	Vous pouvez la poser directement (en anglais) dans la section commentaires sous la vidéo YouTube en question, Alfredo se fera un plaisir d’y répondre. Si cette question porte sur un point précis de la vidéo, pensez à indiquer l’horodatage.
+> Vous pouvez le faire également sur le [Discord](https://discord.gg/CthuqsX8Pb) de la classe dédié expressément aux étudiants. Il sert également à coordonner des groupes de visionnage, discuter des devoirs, suggérer des améliorations ou plus généralement pour tout sujet lié au cours.
 - **Puis-je utiliser ce cours?**  
 > Bien sûr, le cours est placé sous la [Licence internationale Creative Commons Attribution-NonCommercial-ShareAlike 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/deed.fr).
 > Cela signifie que :
@@ -44,12 +45,16 @@ Voici quelques réponses à des questions fréquemment posées :
 > - Dans le cas où vous effectuez un remix, que vous transformez, ou créez à partir du matériel à partir de l'œuvre originale, vous devez diffuser l'œuvre modifiée dans les mêmes conditions, c'est à dire avec la même licence avec laquelle l'œuvre originale a été diffusée. 
 >  
 > - Pour le crédit, vous pouvez utiliser le BibTeX suivant :
+> ```bibtex
 > @misc{canziani2020nyudlsp20,  
-  author = {Canziani, Alfredo and LeCun, Yann},  
-  title = {NYU Deep Learning, Spring 2020},  
-  howpublished = "\url{https://atcold.github.io/pytorch-Deep-Learning/}",  
-  year = {2020},  
-  note = "[Online; accessed <today>]"}
+>   author = {Canziani, Alfredo and LeCun, Yann},  
+>   title = {NYU Deep Learning, Spring 2020},  
+>   howpublished = "\url{https://atcold.github.io/NYU-DLSP20}",  
+>   year = {2020},  
+>   note = "[Online; accessed <today>]"  
+> }
+> ```
+
 
 
 #	Traduction

--- a/docs/fr/faq.md
+++ b/docs/fr/faq.md
@@ -27,33 +27,33 @@ En cas de besoin vous pouvez facilement basculer du site à un moment d’une vi
 
 # FAQ
 Voici quelques réponses à des questions fréquemment posées :
--	**Est-ce que suivre ce cours permet d’obtenir une certification ?**  
->	Non. Pour proposer une certification, il faudrait pouvoir vous évaluer or le contenu n’a pas été prévu pour (contrairement à un MOOC par exemple).    
->	Cette demande étant fréquente, des réflexions sont menées pour essayer d’en proposer une pour des éditions futures du cours.
--	**Une version plus récente du cours existe. Cette édition 2020 est-elle encore valable ?**  
-> Absolument. L’[édition 2021](https://atcold.github.io/NYU-DLSP21/fr/) est sensiblement la même que celle de 2020 mais est présentée d’une façon différente : les travaux dirigés sont maintenant abordés du point de vue des modèles à base d’énergie et les cours magistraux ont été légèrement réorganisées. Les invités diffèrent également. Concernant le français, le site web de l’édition 2021 a été traduit et les trois vidéos des conférenciers invités. Les autres vidéos ne seront pas traduites car son redondantes avec l'édition 2020. Ainsi nous vous conseillons de commencer avec cette édition 2020 pour le français puis explorer par vous-même par la suite l’édition 2021 au besoin. 
--	**Combien de temps consacrer à ce cours ?**  
+- **Est-ce que suivre ce cours permet d’obtenir une certification ?**
+> Non. Pour proposer une certification, il faudrait pouvoir vous évaluer or le contenu n’a pas été prévu pour (contrairement à un MOOC par exemple).
+> Cette demande étant fréquente, des réflexions sont menées pour essayer d’en proposer une pour des éditions futures du cours.
+- **Une version plus récente du cours existe. Cette édition 2020 est-elle encore valable ?**
+> Absolument. L’[édition 2021](https://atcold.github.io/NYU-DLSP21/fr/) est sensiblement la même que celle de 2020 mais est présentée d’une façon différente : les travaux dirigés sont maintenant abordés du point de vue des modèles à base d’énergie et les cours magistraux ont été légèrement réorganisées. Les invités diffèrent également. Concernant le français, le site web de l’édition 2021 a été traduit et les trois vidéos des conférenciers invités. Les autres vidéos ne seront pas traduites car son redondantes avec l'édition 2020. Ainsi nous vous conseillons de commencer avec cette édition 2020 pour le français puis explorer par vous-même par la suite l’édition 2021 au besoin.
+- **Combien de temps consacrer à ce cours ?**
 > Pour chaque semaine, il y a environ 2h30/3h de contenu vidéo. Avec le temps consacré à la prise de notes et celui pour jouer avec les *notebooks*, une estimation totale de 5h par semaine semble raisonnable. Pour la suite, cela dépend du niveau d'immersion que vous voulez atteindre dans un sujet donné (lire les articles donnés en référence, appliquer ce qui a été vu en classe à vos propres projets, etc.).
--	**Où poser une question à l’issue du visionnage d’une vidéo ?**  
->	Vous pouvez la poser directement (en anglais) dans la section commentaires sous la vidéo YouTube en question, Alfredo se fera un plaisir d’y répondre. Si cette question porte sur un point précis de la vidéo, pensez à indiquer l’horodatage.
+- **Où poser une question à l’issue du visionnage d’une vidéo ?**
+> Vous pouvez la poser directement (en anglais) dans la section commentaires sous la vidéo YouTube en question, Alfredo se fera un plaisir d’y répondre. Si cette question porte sur un point précis de la vidéo, pensez à indiquer l’horodatage.
 > Vous pouvez le faire également sur le [Discord](https://discord.gg/CthuqsX8Pb) de la classe dédié expressément aux étudiants. Il sert également à coordonner des groupes de visionnage, discuter des devoirs, suggérer des améliorations ou plus généralement pour tout sujet lié au cours.
-- **Puis-je utiliser ce cours?**  
+- **Puis-je utiliser ce cours?**
 > Bien sûr, le cours est placé sous la [Licence internationale Creative Commons Attribution-NonCommercial-ShareAlike 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/deed.fr).
 > Cela signifie que :
 > - Vous n'êtes pas autorisé à faire un usage commercial de cette œuvre.
 > - Vous devez créditer l'œuvre, intégrer un lien vers la licence et indiquer si des modifications ont été effectuées à l'œuvre. Vous devez indiquer ces informations par tous les moyens raisonnables, sans toutefois suggérer que l'offrant vous soutient ou soutient la façon dont vous avez utilisé son œuvre.
-> - Dans le cas où vous effectuez un remix, que vous transformez, ou créez à partir du matériel à partir de l'œuvre originale, vous devez diffuser l'œuvre modifiée dans les mêmes conditions, c'est à dire avec la même licence avec laquelle l'œuvre originale a été diffusée. 
->  
-> - Pour le crédit, vous pouvez utiliser le BibTeX suivant :
+> - Dans le cas où vous effectuez un remix, que vous transformez, ou créez à partir du matériel à partir de l'œuvre originale, vous devez diffuser l'œuvre modifiée dans les mêmes conditions, c'est à dire avec la même licence avec laquelle l'œuvre originale a été diffusée.
+>
+> Pour le crédit, vous pouvez utiliser le BibTeX suivant :
 > ```bibtex
-> @misc{canziani2020nyudlsp20,  
->   author = {Canziani, Alfredo and LeCun, Yann},  
->   title = {NYU Deep Learning, Spring 2020},  
->   howpublished = "\url{https://atcold.github.io/NYU-DLSP20}",  
->   year = {2020},  
->   note = "[Online; accessed <today>]"  
+> @misc{canziani2020nyudlsp20,
+>   author = {Canziani, Alfredo and LeCun, Yann},
+>   title = {NYU Deep Learning, Spring 2020},
+>   howpublished = "\url{https://atcold.github.io/NYU-DLSP20}",
+>   year = {2020},
+>   note = "[Online; accessed <today>]"
 > }
-> ```
+> `
 
 
 

--- a/docs/fr/faq.md
+++ b/docs/fr/faq.md
@@ -53,7 +53,7 @@ Voici quelques réponses à des questions fréquemment posées :
 >   year = {2020},
 >   note = "[Online; accessed <today>]"
 > }
-> `
+> ```
 
 
 

--- a/docs/fr/print.md
+++ b/docs/fr/print.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Print
+lang: fr
 lang-ref: print
 permalink: /fr/print/
 print_page: true

--- a/docs/fr/print.md
+++ b/docs/fr/print.md
@@ -1,0 +1,7 @@
+---
+layout: default
+title: Print
+lang-ref: print
+permalink: /fr/print/
+print_page: true
+---

--- a/docs/hu/print.md
+++ b/docs/hu/print.md
@@ -1,0 +1,7 @@
+---
+layout: default
+title: Print
+lang-ref: print
+permalink: /hu/print/
+print_page: true
+---

--- a/docs/hu/print.md
+++ b/docs/hu/print.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Print
+lang: hu
 lang-ref: print
 permalink: /hu/print/
 print_page: true

--- a/docs/it/print.md
+++ b/docs/it/print.md
@@ -1,0 +1,7 @@
+---
+layout: default
+title: Print
+lang-ref: print
+permalink: /it/print/
+print_page: true
+---

--- a/docs/it/print.md
+++ b/docs/it/print.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Print
+lang: it
 lang-ref: print
 permalink: /it/print/
 print_page: true

--- a/docs/ja/print.md
+++ b/docs/ja/print.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Print
+lang: ja
 lang-ref: print
 permalink: /ja/print/
 print_page: true

--- a/docs/ja/print.md
+++ b/docs/ja/print.md
@@ -1,0 +1,7 @@
+---
+layout: default
+title: Print
+lang-ref: print
+permalink: /ja/print/
+print_page: true
+---

--- a/docs/ko/print.md
+++ b/docs/ko/print.md
@@ -1,0 +1,7 @@
+---
+layout: default
+title: Print
+lang-ref: print
+permalink: /ko/print/
+print_page: true
+---

--- a/docs/ko/print.md
+++ b/docs/ko/print.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Print
+lang: ko
 lang-ref: print
 permalink: /ko/print/
 print_page: true

--- a/docs/print.md
+++ b/docs/print.md
@@ -1,0 +1,7 @@
+---
+layout: default
+title: Print
+lang-ref: print
+permalink: /print/
+print_page: true
+---

--- a/docs/pt/print.md
+++ b/docs/pt/print.md
@@ -1,0 +1,7 @@
+---
+layout: default
+title: Print
+lang-ref: print
+permalink: /pt/print/
+print_page: true
+---

--- a/docs/pt/print.md
+++ b/docs/pt/print.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Print
+lang: pt
 lang-ref: print
 permalink: /pt/print/
 print_page: true

--- a/docs/ru/print.md
+++ b/docs/ru/print.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Print
+lang: ru
 lang-ref: print
 permalink: /ru/print/
 print_page: true

--- a/docs/ru/print.md
+++ b/docs/ru/print.md
@@ -1,0 +1,7 @@
+---
+layout: default
+title: Print
+lang-ref: print
+permalink: /ru/print/
+print_page: true
+---

--- a/docs/sr/print.md
+++ b/docs/sr/print.md
@@ -1,0 +1,7 @@
+---
+layout: default
+title: Print
+lang-ref: print
+permalink: /sr/print/
+print_page: true
+---

--- a/docs/sr/print.md
+++ b/docs/sr/print.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Print
+lang: sr
 lang-ref: print
 permalink: /sr/print/
 print_page: true

--- a/docs/tr/print.md
+++ b/docs/tr/print.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Print
+lang: tr
 lang-ref: print
 permalink: /tr/print/
 print_page: true

--- a/docs/tr/print.md
+++ b/docs/tr/print.md
@@ -1,0 +1,7 @@
+---
+layout: default
+title: Print
+lang-ref: print
+permalink: /tr/print/
+print_page: true
+---

--- a/docs/vi/print.md
+++ b/docs/vi/print.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Print
+lang: vi
 lang-ref: print
 permalink: /vi/print/
 print_page: true

--- a/docs/vi/print.md
+++ b/docs/vi/print.md
@@ -1,0 +1,7 @@
+---
+layout: default
+title: Print
+lang-ref: print
+permalink: /vi/print/
+print_page: true
+---

--- a/docs/zh/print.md
+++ b/docs/zh/print.md
@@ -1,0 +1,7 @@
+---
+layout: default
+title: Print
+lang-ref: print
+permalink: /zh/print/
+print_page: true
+---

--- a/docs/zh/print.md
+++ b/docs/zh/print.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Print
+lang: zh
 lang-ref: print
 permalink: /zh/print/
 print_page: true


### PR DESCRIPTION
@Atcold What I mentioned to you in my message

Some details about the implementation:
- Everything is handled in the `docs` folder, where need to specify to use my modified version of jekyllbook (https://github.com/lbourdois/jekyllbook). In particular, https://github.com/lbourdois/jekyllbook/blob/master/_layouts/default.html, which contains the main additions (the search bar and the PDF print function, where we had to address quite a few issues such as themes, equation rendering, etc.)
- `_config.yml` contains lines to configure the PDF cover page that I add before printing the site as-is as a PDF
- Add a `print.md` file to generate the PDF in English; for all other languages, you must add a `print.md` file to each language folder (e.g.: https://github.com/lbourdois/NYU-DLSP20/blob/master/docs/fr/print.md)

Loïck